### PR TITLE
Refactor: add useStableCallback and rename props

### DIFF
--- a/.changeset/hungry-icons-grin.md
+++ b/.changeset/hungry-icons-grin.md
@@ -1,0 +1,5 @@
+---
+'dotlottie-solid': minor
+---
+
+Implement useStableCallback and rename dotLottieRef -> dotLottieRefCallback

--- a/README.md
+++ b/README.md
@@ -62,19 +62,19 @@ const App: Component = () => {
 
 The `DotLottieSolidProps` extends the `HTMLCanvasElement` Props and accepts all the props that the `HTMLCanvasElement` accepts. In addition to that, it also accepts the following props:
 
-| Property name         | Type                      | Default              | Description                                                                                                                                                                                                                                           |
-|-----------------------|---------------------------|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `autoplay`              | boolean                 | false                | Auto-starts the animation on load.                                                                                                                                                                                                                    |
-| `loop`                  | boolean                 | false                | Determines if the animation should loop.                                                                                                                                                                                                              |
-| `src`                   | string                  | undefined            | URL to the animation data ( .json  or  .lottie).                                                                                                                                                                                                      |
-| `speed`                 | number                  | 1                    | Animation playback speed. 1 is regular speed.                                                                                                                                                                                                         |
-| `data`                  | string \| ArrayBuffer   | undefined            | Animation data provided either as a Lottie JSON string or as an ArrayBuffer for .lottie animations.                                                                                                                                                   |
-| `mode`                  | string                  | "forward"            | Animation play mode. Accepts "forward", "reverse", "bounce", "reverse-bounce".                                                                                                                                                                        |
+| Property name           | Type                      | Default              | Description                                                                                                                                                                                                                                           |
+|-------------------------|---------------------------|----------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `autoplay`              | boolean                   | false                | Auto-starts the animation on load.                                                                                                                                                                                                                    |
+| `loop`                  | boolean                   | false                | Determines if the animation should loop.                                                                                                                                                                                                              |
+| `src`                   | string                    | undefined            | URL to the animation data ( .json  or  .lottie).                                                                                                                                                                                                      |
+| `speed`                 | number                    | 1                    | Animation playback speed. 1 is regular speed.                                                                                                                                                                                                         |
+| `data`                  | string \| ArrayBuffer     | undefined            | Animation data provided either as a Lottie JSON string or as an ArrayBuffer for .lottie animations.                                                                                                                                                   |
+| `mode`                  | string                    | "forward"            | Animation play mode. Accepts "forward", "reverse", "bounce", "reverse-bounce".                                                                                                                                                                        |
 | `backgroundColor`       | string                    | undefined            | Background color of the canvas. Accepts 6-digit or 8-digit hex color string (e.g., "#000000", "#000000FF"),                                                                                                                                           |
 | `segment`               | [number, number]          | [0, totalFrames - 1] | Animation segment. Accepts an array of two numbers, where the first  number is the start frame and the second number is the end frame.                                                                                                                |
 | `renderConfig`          | RenderConfig              | {}                   | Configuration for rendering the animation.                                                                                                                                                                                                            |
 | `playOnHover`           | boolean                   | false                | Determines if the animation should play on mouse hover and pause on mouse out.                                                                                                                                                                        |
-| `dotLottieRef`          | Setter<DotLottie \| null> | undefined            | Setter function that sets a reference to the  dotLottie web player instance.                                                                                                                                                                          |
+| `dotLottieRefCallback`  | (v: DotLottie) => void    | undefined            | Setter function that sets a reference to the  dotLottie web player instance.                                                                                                                                                                          |
 | `useFrameInterpolation` | boolean                   | true                 | Determines if the animation should update on subframes. If set to false,  the original AE frame rate will be maintained. If set to true, it will  refresh at each requestAnimationFrame, including intermediate values.  The default setting is true. |
 | `autoResizeCanvas`      | boolean                   | true                 | Determines if the canvas should resize automatically to its container                                                                                                                                                                                 |
 | `marker`                | string                    | undefined            | The Lottie named marker to play.                                                                                                                                                                                                                      |
@@ -85,11 +85,11 @@ The `renderConfig` object accepts the following properties:
 
 | Property name      | Type   | Default                       | Description             |
 |--------------------|--------|-------------------------------|-------------------------|
-| `devicePixelRatio` | number | window\.devicePixelRatio \|\| 1 | The device pixel ratio. |
+| `devicePixelRatio` | number | window\.devicePixelRatio \| 1 | The device pixel ratio. |
 
 ## Custom Playback Controls
 
-`DotLottieSolid` component makes it easy to build custom playback controls for the animation. It exposes a `dotLottieRef` prop that can be used to set a reference to the [dotLottie](https://github.com/LottieFiles/dotlottie-web/blob/main/packages/web/README.md#apis) web player instance. This instance can be used to control the playback of the animation using the methods exposed by the [dotLottie](https://github.com/LottieFiles/dotlottie-web/blob/main/packages/web/README.md#methods) web player instance.
+`DotLottieSolid` component makes it easy to build custom playback controls for the animation. It exposes a `dotLottieRefCallback` prop that can be used to get a reference to the [dotLottie](https://github.com/LottieFiles/dotlottie-web/blob/main/packages/web/README.md#apis) web player instance. This instance can be used to control the playback of the animation using the methods exposed by the [dotLottie](https://github.com/LottieFiles/dotlottie-web/blob/main/packages/web/README.md#methods) web player instance.
 
 Here is an example:
 
@@ -101,21 +101,15 @@ const App = () => {
   const [dotLottie, setDotLottie] = Solid.createSignal<DotLottie | null>(null);
 
   function play() {
-    if (dotLottie()) {
-      dotLottie()?.play();
-    }
+    dotLottie()?.play();
   }
 
   function pause() {
-    if (dotLottie()) {
-      dotLottie()?.pause();
-    }
+    dotLottie()?.pause();
   }
 
   function stop() {
-    if (dotLottie()) {
-      dotLottie()?.stop();
-    }
+    dotLottie()?.stop();
   }
 
   return (
@@ -123,7 +117,7 @@ const App = () => {
       src="path/to/animation.lottie"
       loop
       autoplay
-      dotLottieRef={setDotLottie}
+      dotLottieRefCallback={setDotLottie}
     />
     <div>
       <button onClick={play}>Play</button>
@@ -138,7 +132,7 @@ You can find the list of methods that can be used to control the playback of the
 
 ## Listening to Events
 
-`DotLottieSolid` component can receive a `dotLottieRef` prop that can be used to set a reference to the [dotLottie](https://github.com/LottieFiles/dotlottie-web/blob/main/packages/web/README.md#apis) web player instance. This reference can be used to listen to player events emitted by the [dotLottie](https://github.com/LottieFiles/dotlottie-web/blob/main/packages/web/README.md#events) web instance.
+`DotLottieSolid` component can receive a `dotLottieRefCallback` prop that can be used to get a reference to the [dotLottie](https://github.com/LottieFiles/dotlottie-web/blob/main/packages/web/README.md#apis) web player instance. This reference can be used to listen to player events emitted by the [dotLottie](https://github.com/LottieFiles/dotlottie-web/blob/main/packages/web/README.md#events) web instance.
 
 Here is an example:
 
@@ -168,26 +162,26 @@ const App = () => {
 
     // Listen to events emitted by the DotLottie instance when it is available.
     if (dotLottie()) {
-      dotLottie()?.addEventListener('play', onPlay);
-      dotLottie()?.addEventListener('pause', onPause);
-      dotLottie()?.addEventListener('complete', onComplete);
-      dotLottie()?.addEventListener('frame', onFrameChange);
+      dotLottie().addEventListener('play', onPlay);
+      dotLottie().addEventListener('pause', onPause);
+      dotLottie().addEventListener('complete', onComplete);
+      dotLottie().addEventListener('frame', onFrameChange);
     }
   });
 
   Solid.onCleanup(() => {
     // Remove event listeners when the component is unmounted.
     if (dotLottie()) {
-      dotLottie()?.removeEventListener('play', onPlay);
-      dotLottie()?.removeEventListener('pause', onPause);
-      dotLottie()?.removeEventListener('complete', onComplete);
-      dotLottie()?.removeEventListener('frame', onFrameChange);
+      dotLottie().removeEventListener('play', onPlay);
+      dotLottie().removeEventListener('pause', onPause);
+      dotLottie().removeEventListener('complete', onComplete);
+      dotLottie().removeEventListener('frame', onFrameChange);
     }
   });
 
   return (
     <DotLottieSolid
-      dotLottieRef={setDotLottie}
+      dotLottieRefCallback={(v) => setDotLottie(v)}
       src="path/to/animation.lottie"
       loop
       autoplay

--- a/dev/App.tsx
+++ b/dev/App.tsx
@@ -41,7 +41,7 @@ const App: Component = () => {
 			}}
 		>
 			<DotLottieSolid
-				dotLottieRef={setDotlottie}
+				dotLottieRefCallback={setDotlottie}
 				useFrameInterpolation={useFrameInterpolation()}
 				src={animations[srcIdx()]}
 				autoplay

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test": "concurrently pnpm:test:*",
     "test:client": "vitest",
     "test:ssr": "pnpm run test:client --mode ssr",
-    "prepublishOnly": "pnpm build",
+    "prepublish": "pnpm build",
     "format": "prettier --ignore-path .gitignore -w \"src/**/*.{js,ts,json,css,tsx,jsx}\" \"dev/**/*.{js,ts,json,css,tsx,jsx}\"",
     "lint": "concurrently pnpm:lint:*",
     "lint:code": "eslint --ignore-path .gitignore --max-warnings 0 \"src/**/*.{js,ts,tsx,jsx}\"",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dotlottie-solid",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "An unofficial Solid library for rendering lottie and dotLottie animations in the browser.",
   "license": "MIT",
   "author": "moonlitgrace",

--- a/src/dotlottie.tsx
+++ b/src/dotlottie.tsx
@@ -1,5 +1,5 @@
 import type { Config, DotLottie } from '@lottiefiles/dotlottie-web';
-import { ComponentProps, JSX, Setter, createEffect, splitProps } from 'solid-js';
+import { ComponentProps, JSX, createEffect, splitProps } from 'solid-js';
 
 import { useDotLottie } from './use-dotlottie';
 import useStableCallback from './use-stable-callback';
@@ -30,8 +30,10 @@ export const DotLottieSolid = (props: DotLottieSolidProps): JSX.Element => {
 	]);
 	const { DotLottieComponent, dotLottie } = useDotLottie(dotLottieProps);
 
-	const stableDotLottieRefCallback = 
-		typeof dotLottieProps.dotLottieRefCallback === 'function' ? useStableCallback(dotLottieProps.dotLottieRefCallback) : undefined;
+	const stableDotLottieRefCallback =
+		typeof dotLottieProps.dotLottieRefCallback === 'function'
+			? useStableCallback(dotLottieProps.dotLottieRefCallback)
+			: undefined;
 
 	createEffect(() => {
 		if (typeof stableDotLottieRefCallback === 'function') {

--- a/src/dotlottie.tsx
+++ b/src/dotlottie.tsx
@@ -1,14 +1,15 @@
 import type { Config, DotLottie } from '@lottiefiles/dotlottie-web';
+import { ComponentProps, JSX, Setter, createEffect, splitProps } from 'solid-js';
 
 import { useDotLottie } from './use-dotlottie';
-import { ComponentProps, JSX, Setter, createEffect, splitProps } from 'solid-js';
+import useStableCallback from './use-stable-callback';
 
 export type DotLottieSolidProps = Omit<Config, 'canvas'> &
 	ComponentProps<'canvas'> &
 	Partial<{
-		autoResizeCanvas?: boolean;
-		dotLottieRef: Setter<DotLottie | null>;
-		playOnHover?: boolean;
+		autoResizeCanvas: boolean;
+		dotLottieRefCallback: (dotLottie: DotLottie) => void;
+		playOnHover: boolean;
 	}>;
 
 export const DotLottieSolid = (props: DotLottieSolidProps): JSX.Element => {
@@ -23,14 +24,19 @@ export const DotLottieSolid = (props: DotLottieSolidProps): JSX.Element => {
 		'autoplay',
 		'playOnHover',
 		'renderConfig',
-		'dotLottieRef',
 		'autoResizeCanvas',
+		'dotLottieRefCallback',
 		'useFrameInterpolation',
 	]);
 	const { DotLottieComponent, dotLottie } = useDotLottie(dotLottieProps);
 
+	const stableDotLottieRefCallback = 
+		typeof dotLottieProps.dotLottieRefCallback === 'function' ? useStableCallback(dotLottieProps.dotLottieRefCallback) : undefined;
+
 	createEffect(() => {
-		dotLottieProps.dotLottieRef?.(dotLottie());
+		if (typeof stableDotLottieRefCallback === 'function') {
+			stableDotLottieRefCallback(dotLottie()!);
+		}
 	});
 
 	return <DotLottieComponent {...restProps} />;

--- a/src/use-stable-callback.tsx
+++ b/src/use-stable-callback.tsx
@@ -1,0 +1,11 @@
+import { createEffect, createSignal } from "solid-js";
+
+export default function useStableCallback<Args extends unknown[], T>(callback: (...args: Args) => T): (...args: Args) => T {
+	const [getCallback, setCallback] = createSignal(callback);
+
+	createEffect(() => {
+		setCallback(() => callback);
+	})
+
+	return (...args: Args) => getCallback()(...args);
+};

--- a/src/use-stable-callback.tsx
+++ b/src/use-stable-callback.tsx
@@ -1,11 +1,13 @@
-import { createEffect, createSignal } from "solid-js";
+import { createEffect, createSignal } from 'solid-js';
 
-export default function useStableCallback<Args extends unknown[], T>(callback: (...args: Args) => T): (...args: Args) => T {
+export default function useStableCallback<Args extends unknown[], T>(
+	callback: (...args: Args) => T,
+): (...args: Args) => T {
 	const [getCallback, setCallback] = createSignal(callback);
 
 	createEffect(() => {
 		setCallback(() => callback);
-	})
+	});
 
 	return (...args: Args) => getCallback()(...args);
-};
+}


### PR DESCRIPTION
add `useStableCallback` for stable reference.
rename `dotLottieRef` to `dotLottieRefCallback`